### PR TITLE
WhereNet flexible contrast dataset for training

### DIFF
--- a/notebooks/where.py
+++ b/notebooks/where.py
@@ -142,7 +142,7 @@ def MotionCloudNoise(sf_0=0.125, B_sf=3., alpha=.0, N_pic=28, seed=42):
     return z, env
 
 class RetinaBackground:
-    def __init__(self, contrast=1., noise=1., sf_0=.1, B_sf=.1):
+    def __init__(self, contrast=1., noise=1., sf_0=.1, B_sf=.1, flexible=True): #flexible contrast parameter
         self.contrast = contrast
         self.noise = noise
         self.sf_0 = sf_0
@@ -158,7 +158,10 @@ class RetinaBackground:
         if pixel_fullfield.min() != pixel_fullfield.max():
             fullfield = (pixel_fullfield - pixel_fullfield.min()) / (pixel_fullfield.max() - pixel_fullfield.min())
             fullfield = 2 * fullfield - 1  # go to [-1, 1] range
-            fullfield *= self.contrast
+            if self.flexible:
+                fullfield *= np.random.uniform(low=self.contrast, high=0.7)
+            else:
+                fullfield *= self.contrast
             fullfield = fullfield / 2 + 0.5 # back to [0, 1] range
         else:
             fullfield = np.zeros((N_pic, N_pic))


### PR DESCRIPTION
Adding optional parameter in RetinaBackground to have a **flexible contrast**, _varies between 0.7 and the chosen contrast_ if the parameter is set to True (by default), the flexible contrast feature is implemented in the WhatBackground but was missing in the Where background class.